### PR TITLE
docs: fix Qdrant collection mention README.md

### DIFF
--- a/actors/qdrant/README.md
+++ b/actors/qdrant/README.md
@@ -35,7 +35,7 @@ The configuration consists of three parts: Qdrant, embeddings provider, and data
 
 Ensure that the vector size of your embeddings aligns with the configuration of your Qdrant settings. 
 For instance, if you're using the `text-embedding-3-small` model from `OpenAI`, it generates vectors of size `1536`. 
-This means your Pinecone index should also be configured to accommodate vectors of the same size, `1536` in this case.
+This means your Qdrant collection should also be configured to accommodate vectors of the same size, `1536` in this case.
 
 #### Database: Qdrant
 ```json


### PR DESCRIPTION
Fixes a typo from #19. It's on the integration homepage. 